### PR TITLE
Fix tag release on main build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
           # Comment out when you are upgrading gradle in a branch and doing tons of commits you would need to test.
           # cache-read-only: false
       - name: "Tag release"
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: tagRelease --console=plain --info --stacktrace


### PR DESCRIPTION
## Context

Currently the main build is not publishing a new release, because we are checking if the branch is "master".

Fixing the check to check if it is indeed "main" branch. 

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
