### PR TITLE
Add archival notice for repository migration to closed source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+> **This repository is no longer open source**
+>
+> To better serve Wise business and customer needs, this library is no longer open source and will not receive further public updates. The codebase has moved to our internal systems.
+>
+> **For continued development and access, please refer to the internal repository:**
+> https://github.com/transferwise/wise-environment-private
+
 # Wise Environment.
 
 ![Apache 2](https://img.shields.io/hexpm/l/plug.svg)


### PR DESCRIPTION
## Context

To better serve Wise business and customer needs, this library is no longer open source and will not receive further public updates. The codebases have moved to internal systems.

This PR adds a prominent deprecation notice at the beginning of the README about this change.